### PR TITLE
Fix clearing test output buffer

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -357,7 +357,8 @@ With a prefix ARG, allow editing."
           (user-error "Aborting; pytest still running")))
       (when process
         (delete-process process))
-      (erase-buffer)
+      (let ((inhibit-read-only t))
+        (erase-buffer))
       (unless (eq major-mode 'python-pytest-mode)
         (python-pytest-mode))
       (compilation-forget-errors)


### PR DESCRIPTION
If we try to run a test without closing previous results buffer it will fail with error: `Text is read-only` in mini-buffer.