### PR TITLE
Add very verbose option

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -135,7 +135,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
     (?q "quiet" "--quiet")
     (?s "do not capture output" "--capture=no")
     (?t "do not cut tracebacks" "--full-trace")
-    (?v "verbose" python-pytest--cycle-verbosity)
+    (?v python-pytest--cycle-verbosity "verbose")
     (?x "exit after first failure" "--exitfirst"))
   :options
   '((?k "only names matching expression" "-k")

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -133,6 +133,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
     (?s "do not capture output" "--capture=no")
     (?t "do not cut tracebacks" "--full-trace")
     (?v "verbose" "--verbose")
+    (?w "very verbose" "-vv")
     (?x "exit after first failure" "--exitfirst"))
   :options
   '((?k "only names matching expression" "-k")

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -135,7 +135,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
     (?q "quiet" "--quiet")
     (?s "do not capture output" "--capture=no")
     (?t "do not cut tracebacks" "--full-trace")
-    (?v "verbose" "--verbose" python-pytest--cycle-verbosity)
+    (?v "verbose" python-pytest--cycle-verbosity)
     (?x "exit after first failure" "--exitfirst"))
   :options
   '((?k "only names matching expression" "-k")

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -116,11 +116,15 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
 (defvar-local python-pytest--current-command nil
   "Current command; used in python-pytest-mode buffers.")
 
+(defvar-local python-pytest--verbosity-level 0
+  "Verbosity level.")
+
 (fmakunbound 'python-pytest-popup)
 (makunbound 'python-pytest-popup)
 
 ;;;###autoload (autoload 'python-pytest-popup "python-pytest" nil t)
-(magit-define-popup python-pytest-popup
+(magit
+ -define-popup python-pytest-popup
   "Show popup for running pytest."
   'python-pytest
   :switches
@@ -132,8 +136,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
     (?q "quiet" "--quiet")
     (?s "do not capture output" "--capture=no")
     (?t "do not cut tracebacks" "--full-trace")
-    (?v "verbose" "--verbose")
-    (?w "very verbose" "-vv")
+    (?v "verbose" "--verbose" python-pytest--cycle-verbosity)
     (?x "exit after first failure" "--exitfirst"))
   :options
   '((?k "only names matching expression" "-k")
@@ -560,6 +563,18 @@ Example: ‘MyABCThingy.__repr__’ becomes ‘test_my_abc_thingy_repr’."
         (with-current-buffer it
           (save-buffer)))))
    (t nil)))
+
+
+(defun python-pytest--cycle-verbosity ()
+  "Cycle the verbosity level from 0 (no -v flag) to 2 (-vv flag)."
+  (cond
+   ((memq python-pytest--verbosity '(0 1))
+    (setq python-pytest--verbosity (+ 1 python-pytest--verbosity)))
+   (t (setq python-pytest--verbosity 0)))
+  (cond
+   ((= python-pytest--verbosity 0) "")
+   ((= python-pytest--verbosity 1) "-v")
+   ((= python-pytest--verbosity 2) "-vv")))
 
 
 ;; third party integration

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -123,8 +123,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
 (makunbound 'python-pytest-popup)
 
 ;;;###autoload (autoload 'python-pytest-popup "python-pytest" nil t)
-(magit
- -define-popup python-pytest-popup
+(magit-define-popup python-pytest-popup
   "Show popup for running pytest."
   'python-pytest
   :switches

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -135,7 +135,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
     (?q "quiet" "--quiet")
     (?s "do not capture output" "--capture=no")
     (?t "do not cut tracebacks" "--full-trace")
-    (?v python-pytest--cycle-verbosity "verbose")
+    (?v "verbose" python-pytest--cycle-verbosity)
     (?x "exit after first failure" "--exitfirst"))
   :options
   '((?k "only names matching expression" "-k")


### PR DESCRIPTION
Pytest has an option for higher verbosity, which will display the full diff for objects that fail equality assertion (`-vv`). In my work, I've found the flag to be indispensable for TDD. This PR adds the `-vv` flag as an option in the magit popup menu.