### PR TITLE
Switch to use transient.el

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,11 +18,11 @@ __ https://www.gnu.org/software/emacs/
 __ https://pytest.org/
 
 most functionality can be used via
-a dispatcher popup menu built using `magit-popup`__,
+a dispatcher popup menu built using `transient`__,
 which gives a look and feel
 similar to the fantastic `magit`__ package.
 
-__ https://magit.vc/manual/magit-popup.html
+__ https://magit.vc/manual/transient
 __ https://magit.vc/
 
 
@@ -81,22 +81,19 @@ screenshot
    -s do not capture output (--capture=no)
    -t do not cut tracebacks (--full-trace)
    -v verbose (--verbose)
+   -w very verbose (--verbose --verbose)
    -x exit after first failure (--exitfirst)
 
   Options
-   =k only names matching expression (-k)
-   =m only marks matching expression (-m)
+   =k only names matching expression (-k=)
+   =m only marks matching expression (-m=)
    =t traceback style (--tb=)
-   =x exit after N failures or errors (--maxfail="10")
+   =x exit after N failures or errors (--maxfail=)
 
-  Run tests
-   t Test all                r Repeat last test run    x Test last-failed
-
-  Run tests for specific files
-   f Test file (dwim)       F Test this file         m Test multiple files
-
-  Run tests for current function/class
-   d Test def/class (dwim)    D Test this def/class
+  Run tests                 Run tests for specific files              Run tests for current function/class
+   t Test all                f Test file (dwim)                        d Test def/class (dwim)
+   r Repeat last test run    F Test this file                          D Test this def/classx
+   x Test last-failed        m Test multiple files
 
 
 installation
@@ -316,9 +313,9 @@ extending the popup
 
 when using pytest plugins that provide extra switches,
 it may be useful to integrate those into the popup.
-see the `magit-popup`__ manual for more information.
+see the `transient`__ manual for more information.
 
-__ https://magit.vc/manual/magit-popup.html
+__ https://magit.vc/manual/transient
 
 as an example, this will add a ``-z`` switch that,
 when enabled, will invoke ``pytest --zzz``:
@@ -327,8 +324,10 @@ when enabled, will invoke ``pytest --zzz``:
 
   (use-package python-pytest
    :config
-   (magit-define-popup-switch 'python-pytest-popup
-    ?z "Custom flag" "--zzz"))
+   (transient-append-suffix
+     'foo-popup2
+     "-x"
+     '("-z" "Custom flag" "--zzz")))
 
 
 contributing

--- a/README.rst
+++ b/README.rst
@@ -130,13 +130,13 @@ basics
 ------
 
 the typical usage pattern is to invoke the popup menu,
-named ``python-pytest-popup``.
+named ``python-pytest-dispatch``.
 it is a good idea to create a dedicated keybinding for this command,
 but it can also be run manually:
 
 ::
 
-  M-x python-pytest-popup
+  M-x python-pytest-dispatch
 
 this shows a dispatcher menu.
 change some switches and options,
@@ -331,7 +331,7 @@ when enabled, will invoke ``pytest --zzz``:
 
 
 `transient` lets you save defaults you want for it. Just
-select all options on ``python-pytest-popup`` and then
+select all options on ``python-pytest-dispatch`` and then
 - ``C-x C-s`` to save current settings as default and make
   them persistent,
 - ``C-x s`` to save current settings as default for the
@@ -397,7 +397,7 @@ __ https://stable.melpa.org/
 ------------------
 
 * repopulate the popup with the previously used values
-  when running ``python-pytest-popup`` from an output buffer.
+  when running ``python-pytest-dispatch`` from an output buffer.
   (`#3 <https://github.com/wbolster/emacs-python-pytest/issues/3>`_)
 
 0.2.2 (2018-02-26)

--- a/README.rst
+++ b/README.rst
@@ -330,6 +330,13 @@ when enabled, will invoke ``pytest --zzz``:
      '("-z" "Custom flag" "--zzz")))
 
 
+`transient` lets you save defaults you want for it. Just
+select all options on ``python-pytest-popup`` and then
+- ``C-x C-s`` to save current settings as default and make
+  them persistent,
+- ``C-x s`` to save current settings as default for the
+  current emacs session.
+
 contributing
 ============
 

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -116,11 +116,11 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
 (defvar-local python-pytest--current-command nil
   "Current command; used in python-pytest-mode buffers.")
 
-(fmakunbound 'python-pytest-popup)
-(makunbound 'python-pytest-popup)
+(fmakunbound 'python-pytest-dispatch)
+(makunbound 'python-pytest-dispatch)
 
-;;;###autoload (autoload 'python-pytest-popup "python-pytest" nil t)
-(define-transient-command python-pytest-popup ()
+;;;###autoload (autoload 'python-pytest-dispatch "python-pytest" nil t)
+(define-transient-command python-pytest-dispatch ()
   "Show popup for running pytest."
   :man-page "pytest"
   :incompatible '(("--verbose" "--verbose --verbose"))
@@ -140,7 +140,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
   ["Options"
    ("=k" "only names matching expression" "-k=")
    ("=m" "only marks matching expression" "-m=")
-   (python-pytest-popup:--tb)
+   (python-pytest-dispatch:--tb)
    ("=x" "exit after N failures or errors" "--maxfail=")]
   [["Run tests"
     ("t" "Test all" python-pytest)
@@ -153,6 +153,9 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
    ["Run tests for current function/class"
     ("d" "Test def/class (dwim)" python-pytest-function-dwim)
     ("D" "Test this def/class" python-pytest-function)]])
+
+(define-obsolete-function-alias 'python-pytest-popup
+  'python-pytest-dispatch "python-pytest 0.3.2")
 
 ;;;###autoload
 (defun python-pytest (&optional args)
@@ -427,7 +430,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
           (format "%s %s" option it)))
    args))
 
-(transient-define-argument python-pytest-popup:--tb ()
+(transient-define-argument python-pytest-dispatch:--tb ()
   :description "traceback style"
   :class 'transient-option
   :key "=t"
@@ -435,7 +438,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
   :choices '("long" "short" "line" "native" "no"))
 
 (defun python-pytest-arguments ()
-  (transient-args 'python-pytest-popup))
+  (transient-args 'python-pytest-dispatch))
 
 
 ;; python helpers

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -116,9 +116,6 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
 (defvar-local python-pytest--current-command nil
   "Current command; used in python-pytest-mode buffers.")
 
-(fmakunbound 'python-pytest-dispatch)
-(makunbound 'python-pytest-dispatch)
-
 ;;;###autoload (autoload 'python-pytest-dispatch "python-pytest" nil t)
 (define-transient-command python-pytest-dispatch ()
   "Show popup for running pytest."

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -151,8 +151,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
     ("d" "Test def/class (dwim)" python-pytest-function-dwim)
     ("D" "Test this def/class" python-pytest-function)]])
 
-(define-obsolete-function-alias 'python-pytest-popup
-  'python-pytest-dispatch "python-pytest 0.3.2")
+(define-obsolete-function-alias 'python-pytest-popup 'python-pytest-dispatch)
 
 ;;;###autoload
 (defun python-pytest (&optional args)


### PR DESCRIPTION
`transient` is a replacement to `magit-popup` and even `magit` has already switched to use `transient`.

This fixes #18.

The switch is pretty idiomatic, however there are a few differences.

The default layout is slightly different but I didn't try to replace it as the new one seems to match what `magit` is presenting these days. I think that the new layout resembles more what `magit` is presenting these days, but I don't have any scientific method for that. Happy to work on changing to original layout if this is desired.

The concept of `:default-action` seems to be gone, so I did not replace it.

The `magit-with-pre-popup-buffer` doesn't seem to have an obvious replacement, however the documentation for `transient--original-buffer` suggest that the `transient` popup is not changing the current buffer. I validated that with a check that the `current-buffer` returns expected `pytest` buffer while invoking `python-pytest` via `python-pytest-popup`.