### PR TITLE
Add a python-pytest-directories command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -368,6 +368,14 @@ __ https://melpa.org/
 __ https://stable.melpa.org/
 
 
+3.0.0 (not yet released)
+------------------------
+
+* add a ``python-pytest-directories`` command with interactive
+  multi-directory selection
+  (`#21 <https://github.com/wbolster/emacs-python-pytest/issues/21>`_)
+  (`#31 <https://github.com/wbolster/emacs-python-pytest/pull/31>`_)
+
 2.0.0 (2020-08-04)
 ------------------
 
@@ -376,9 +384,10 @@ __ https://stable.melpa.org/
   (`#18 <https://github.com/wbolster/emacs-python-pytest/issues/18>`_)
   (`#26 <https://github.com/wbolster/emacs-python-pytest/pull/26>`_)
 
-* add python-pytest-files command with interactive multi-file selection
+* add ``python-pytest-files`` command with interactive multi-file
+  selection
 
-* improve python-pytest-file-dwim heuristic for nested functions/classes
+* improve ``python-pytest-file-dwim`` heuristic for nested functions/classes
 
 * make ``next-error`` and related-commands work
 


### PR DESCRIPTION
This is like python-pytest-files, but for directories:
it interactively prompts for directories (only those containing test
files), then runs only tests in those directories.

A variant to select only a single directory doesn't add much value,
since the multi-select version can also be used to select only
a single directory.

Fixes #21.