### PR TITLE
Respect projectile-compilation-dir if it exists.

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -534,7 +534,7 @@ Example: ‘MyABCThingy.__repr__’ becomes ‘test_my_abc_thingy_repr’."
 (defun python-pytest--project-root ()
   "Find the project root directory."
   (let ((projectile-require-project-root nil))
-    (projectile-project-root)))
+    (projectile-compilation-dir)))
 
 (defun python-pytest--relative-file-name (file)
   "Make FILE relative to the project root."


### PR DESCRIPTION
This allows you to customise the start directory using
.dir-locals and the projectile-project-compilation-dir variable.

If that is not defined, it falls back to projectile-project-root.

Fixes #57 