### PR TITLE
Use read-shell-command instead of read-from-minibuffer (#60) 

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -356,9 +356,9 @@ With a prefix ARG, allow editing."
       (setq edit (not edit)))
     (when edit
       (setq command
-            (read-from-minibuffer
+            (read-shell-command
              "Command: "
-             command nil nil 'python-pytest--history)))
+             command 'python-pytest--history)))
     (add-to-history 'python-pytest--history command)
     (setq python-pytest--history (-uniq python-pytest--history))
     (puthash (python-pytest--project-root) command


### PR DESCRIPTION
The primary advantage of this is that tab completion completes from files in the CWD, which is much more useful for pytest (where test files are valid arguments).

I've tested and everything else seems to work the same, which is what you'd expect from the docs:

```
read-shell-command is a compiled Lisp function in ‘simple.el’.

(read-shell-command PROMPT &optional INITIAL-CONTENTS HIST &rest ARGS)

Read a shell command from the minibuffer.
The arguments are the same as the ones of ‘read-from-minibuffer’,
except READ and KEYMAP are missing and HIST defaults
to ‘shell-command-history’.
```

In our case we are still passing HIST explicitly so that bit makes no difference.

Thanks again for the package, I'm using it every day!

