### PR TITLE
Add `0` as a valid argument that can be passed to `-n`.

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -484,7 +484,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
   :class 'transient-option
   :key "-n"
   :argument "--numprocesses="
-  :choices '("auto" "1" "2" "4" "8" "16"))
+  :choices '("auto" "0" "1" "2" "4" "8" "16"))
 
 
 ;; python helpers


### PR DESCRIPTION
`0` is a valid choice as well https://github.com/pytest-dev/pytest-xdist/blob/8616ff368c8361b5cd421579e071fd24306e242a/src/xdist/plugin.py#L67