### PR TITLE
Make "-v" argument-regexp match complete string

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -479,7 +479,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
   :class 'transient-switches
   :key "-v"
   :argument-format "%s"
-  :argument-regexp "\\(--verbose\\|--verbose --verbose\\)"
+  :argument-regexp "^\\(--verbose\\|--verbose --verbose\\)$"
   :choices '("--verbose" "--verbose --verbose"))
 
 (transient-define-argument python-pytest:--tb ()


### PR DESCRIPTION
Prevents invalid substring matches for "--verbose --verbose" init value.

Closes #63.