### PR TITLE
Add Windows support

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -398,9 +398,10 @@ With a prefix ARG, allow editing."
          'python-pdbtrack-comint-output-filter-function
          nil t))
       (run-hooks 'python-pytest-setup-hook)
-      (if (eq system-type 'windows-nt)
-          (make-comint-in-buffer "pytest" buffer "cmdproxy" nil "/c" command)
-        (make-comint-in-buffer "pytest" buffer "sh" nil "-c" command))
+      (make-comint-in-buffer
+       "pytest" buffer
+       (if (eq system-type 'windows-nt) "cmdproxy" "sh")
+       nil "-c" command)
       (run-hooks 'python-pytest-started-hook)
       (setq process (get-buffer-process buffer))
       (set-process-sentinel process #'python-pytest--process-sentinel))))


### PR DESCRIPTION
On Windows there is no "sh -c" available, so run "cmd /c" instead.