### PR TITLE
add -W argument to ignore warnings

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -125,6 +125,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
    [("-c" "color" "--color")
     ("-q" "quiet" "--quiet")
     ("-s" "no output capture" "--capture=no")
+    ("-w" "disable warnings" "-W ignore")
     (python-pytest:-v)]]
   ["Selection, filtering, ordering"
    [(python-pytest:-k)

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -125,7 +125,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
    [("-c" "color" "--color")
     ("-q" "quiet" "--quiet")
     ("-s" "no output capture" "--capture=no")
-    ("-w" "disable warnings" "-W ignore")
+    ("-W" "ignore warnings" "-W ignore")
     (python-pytest:-v)]]
   ["Selection, filtering, ordering"
    [(python-pytest:-k)

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -125,8 +125,8 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
    [("-c" "color" "--color")
     ("-q" "quiet" "--quiet")
     ("-s" "no output capture" "--capture=no")
-    ("-W" "ignore warnings" "-W ignore")
-    (python-pytest:-v)]]
+    (python-pytest:-v)
+    ("-W" "ignore warnings" "-W ignore")]]
   ["Selection, filtering, ordering"
    [(python-pytest:-k)
     (python-pytest:-m)


### PR DESCRIPTION
sometimes you'd like to ignore warnings but there is no argument for it. WDYT