### PR TITLE
feat: add project.el support

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -611,12 +611,7 @@ Example: ‘MyABCThingy.__repr__’ becomes ‘test_my_abc_thingy_repr’."
       (projectile-test-file-p file)
     (let ((base-name (file-name-nondirectory file)))
       (or (string-prefix-p "test_" base-name)
-          (string-suffix-p "_test.py" base-name)
-          (with-temp-buffer
-            (insert-file-contents file)
-            (goto-char (point-min))
-            (save-excursion
-              (re-search-forward "\\_<import +\\(unittest\\|pytest\\)\\_>" nil t)))))))
+          (string-suffix-p "_test.py" base-name)))))
 
 (defun python-pytest--find-test-file (file)
   "Find a test file associated to FILE, if any."

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -672,7 +672,8 @@ Example: ‘MyABCThingy.__repr__’ becomes ‘test_my_abc_thingy_repr’."
                                                     sorted-test-files))
                                       (cl-delete-duplicates sorted-test-files
                                                             :test 'equal )))
-                        (when (python-pytest--test-file-p file)
+                        (when (and (file-exists-p file)
+                                   (python-pytest--test-file-p file))
                           (push (expand-file-name file) recentf-test-files))))))
               test-files-prj)))
          (test-directories
@@ -702,7 +703,7 @@ Example: ‘MyABCThingy.__repr__’ becomes ‘test_my_abc_thingy_repr’."
         ((buffers
           (if (python-pytest--using-projectile)
               (projectile-buffers-with-file (projectile-project-buffers))
-            (project-buffers (project-current t))))
+            (-filter 'buffer-file-name (project-buffers (project-current t)))))
          (modified-buffers
           (-filter 'buffer-modified-p buffers))
          (confirmed


### PR DESCRIPTION
* see https://github.com/wbolster/emacs-python-pytest/issues/55 
** does not replace projectile, but simply adds project.el support. 
** projectile is still default if installed and projectile-mode active.