### PR TITLE
Add option --log-cli-level in python-pytest-dispatch

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -146,7 +146,8 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
    [("-c" "color" "--color")
     ("-q" "quiet" "--quiet")
     ("-s" "no output capture" "--capture=no")
-    (python-pytest:-v)]]
+    (python-pytest:-v)
+    (python-pytest:--l)]]
   ["Selection, filtering, ordering"
    [(python-pytest:-k)
     (python-pytest:-m)
@@ -483,6 +484,13 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
          (quoted-input (python-pytest--shell-quote input))
          (formatted-input (format " %s" quoted-input)))
     formatted-input))
+
+(transient-define-argument python-pytest:--l ()
+  :description "set log cli level"
+  :class 'transient-option
+  :key "--l"
+  :argument "--log-cli-level="
+  :choices '("debug" "info" "warning" "error" "critical"))
 
 (transient-define-argument python-pytest:-k ()
   :description "only names matching expression"


### PR DESCRIPTION
When writing tests, I usually display debugging information by using `logging.info(...)` or `logging.debug(...)`. When `--log-cli-level=debug` is passed to `pytest`, `logging.info` and `logging.debug` messages are shown. When `--log-cli-level=info` is passed to `pytest`, `logging.info` messages are shown. In this pull request, I introduce changes to include `--log-cli-level` in `python-pytest-dispatch` so that users can conveniently toggle this option.

I wanted to use `-l` as the shortcut for setting `--log-cli-level`, but `-l` is already used in `python-pytest-dispatch` for setting `--showlocals`. For this reason, I ended up using `--l`.

It is worth mentioning that pytest not only defines `--log-cli-level`, but it also defines  `--log-level`, `--log-file-level`. However, I don't know what `--log-level` and `--log-file-level` are used for. I have only used `--log-cli-level` because suits my use case

```
$ pytest --help
logging:
  --log-level=LEVEL     Level of messages to catch/display. Not set by default,
                        so it depends on the root/parent log handler's effective
                        level, where it is "WARNING" by default.
  --log-format=LOG_FORMAT
                        Log format used by the logging module
  --log-date-format=LOG_DATE_FORMAT
                        Log date format used by the logging module
  --log-cli-level=LOG_CLI_LEVEL
                        CLI logging level
  --log-cli-format=LOG_CLI_FORMAT
                        Log format used by the logging module
  --log-cli-date-format=LOG_CLI_DATE_FORMAT
                        Log date format used by the logging module
  --log-file=LOG_FILE   Path to a file when logging will be written to
  --log-file-mode={w,a}
                        Log file open mode
  --log-file-level=LOG_FILE_LEVEL
                        Log file logging level
  --log-file-format=LOG_FILE_FORMAT
                        Log format used by the logging module
  --log-file-date-format=LOG_FILE_DATE_FORMAT
                        Log date format used by the logging module
  --log-auto-indent=LOG_AUTO_INDENT
                        Auto-indent multiline messages passed to the logging
                        module. Accepts true|on, false|off or an integer.
  --log-disable=LOGGER_DISABLE
                        Disable a logger by name. Can be passed multiple times.
```