### PR TITLE
Use tree sitter for getting the node id (aka test id) for the function and class at point

### DIFF
--- a/python-pytest.el
+++ b/python-pytest.el
@@ -127,7 +127,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
            (set-default symbol value)
            value))))
 
-(defcustom python-pytest-use-treesit nil
+(defcustom python-pytest-use-treesit (featurep 'treesit)
   "Whether to use treesit for getting the node ids of things at point.
 
 Users that are running a version of Emacs that supports treesit

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -29,6 +29,7 @@
 
 (require 'projectile nil t)
 (require 'project nil t)
+(require 'treesit nil t)
 
 (defgroup python-pytest nil
   "pytest integration"

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -597,6 +597,15 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
           (throw 'return t))))))
 
 (defun python-pytest--path-def-at-point ()
+  "Return the node id of the def at point.
+
++ If the test function is not inside a class, its node id is the name
+  of the function.
++ If the test function is defined inside a class, its node id would
+  look like: TestGroup::test_my_function.
++ If the test function is defined inside a class that is defined
+  inside another class, its node id would look like:
+  TestGroupParent::TestGroupChild::test_my_function."
   (unless (python-pytest--point-is-inside-def)
     (error "The point is not inside a def."))
   (let ((function
@@ -648,6 +657,14 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
     (string-join `(,@parents ,(cdr function)) "::")))
 
 (defun python-pytest--path-class-at-point ()
+  "Return the node id of the class at point.
+
++ If the class is not inside another class, its node id is the name
+  of the class.
++ If the class is defined inside another class, the node id of the
+  class which is contained would be: TestGroupParent::TestGroupChild,
+  while the node id of the class which contains the other class would
+  be TestGroupParent."
   (unless (python-pytest--point-is-inside-class)
     (error "The point is not inside a class."))
   (let ((class

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -284,11 +284,10 @@ With a prefix argument, allow editing."
 
 Additional ARGS are passed along to pytest.
 With a prefix argument, allow editing."
-  (declare (obsolete 'python-pytest-run-def-at-point "python-pytest 3.5.0"))
   (interactive
    (list
     (buffer-file-name)
-    (python-pytest--node-id-def-at-point)
+    (python-pytest--current-defun)
     (transient-args 'python-pytest-dispatch)))
   (python-pytest--run
    :args args
@@ -313,7 +312,7 @@ With a prefix argument, allow editing."
   (interactive
    (list
     (buffer-file-name)
-    (python-pytest--node-id-def-at-point)
+    (python-pytest--current-defun)
     (transient-args 'python-pytest-dispatch)))
   (unless (python-pytest--test-file-p file)
     (setq
@@ -706,7 +705,6 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
 
 (defun python-pytest--current-defun ()
   "Detect the current function/class (if any)."
-  (declare (obsolete 'python-pytest--node-id-def-at-point "python-pytest 3.5.0"))
   (let* ((name
           (or (python-info-current-defun)
               (save-excursion

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -287,7 +287,7 @@ With a prefix argument, allow editing."
   (interactive
    (list
     (buffer-file-name)
-    (python-pytest--current-defun)
+    (python-pytest--path-def-at-point)
     (transient-args 'python-pytest-dispatch)))
   (python-pytest--run
    :args args
@@ -307,7 +307,7 @@ With a prefix argument, allow editing."
   (interactive
    (list
     (buffer-file-name)
-    (python-pytest--current-defun)
+    (python-pytest--path-def-at-point)
     (transient-args 'python-pytest-dispatch)))
   (unless (python-pytest--test-file-p file)
     (setq
@@ -679,6 +679,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
 
 (defun python-pytest--current-defun ()
   "Detect the current function/class (if any)."
+  (declare (obsolete 'python-pytest--path-def-at-point "python-pytest 3.5.0"))
   (let* ((name
           (or (python-info-current-defun)
               (save-excursion

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -179,8 +179,8 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
    [("m" "files" python-pytest-files)
     ("M" "directories" python-pytest-directories)]
    [("d" "def at point (dwim)" python-pytest-run-def-at-point-dwim)
-    ("D" "def at point" python-pytest-run-def-at-point)
-    ("c" "class at point" python-pytest-run-class-at-point)]])
+    ("D" "def at point" python-pytest-run-def-at-point-treesit)
+    ("c" "class at point" python-pytest-run-class-at-point-treesit)]])
 
 (define-obsolete-function-alias 'python-pytest-popup 'python-pytest-dispatch "2.0.0")
 
@@ -259,23 +259,23 @@ With a prefix argument, allow editing."
    :edit current-prefix-arg))
 
 ;;;###autoload
-(defun python-pytest-run-def-at-point ()
+(defun python-pytest-run-def-at-point-treesit ()
   "Run def at point."
   (interactive)
   (python-pytest--run
    :args (transient-args 'python-pytest-dispatch)
    :file (buffer-file-name)
-   :node-id (python-pytest--node-id-def-at-point)
+   :node-id (python-pytest--node-id-def-at-point-treesit)
    :edit current-prefix-arg))
 
 ;;;###autoload
-(defun python-pytest-run-class-at-point ()
+(defun python-pytest-run-class-at-point-treesit ()
   "Run class at point."
   (interactive)
   (python-pytest--run
    :args (transient-args 'python-pytest-dispatch)
    :file (buffer-file-name)
-   :node-id (python-pytest--node-id-class-at-point)
+   :node-id (python-pytest--node-id-class-at-point-treesit)
    :edit current-prefix-arg))
 
 ;;;###autoload
@@ -596,7 +596,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
         (when (equal (treesit-node-type current-node) "class_definition")
           (throw 'return t))))))
 
-(defun python-pytest--node-id-def-at-point ()
+(defun python-pytest--node-id-def-at-point-treesit ()
   "Return the node id of the def at point.
 
 + If the test function is not inside a class, its node id is the name
@@ -660,7 +660,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
                     parents))))))
     (string-join `(,@parents ,(cdr function)) "::")))
 
-(defun python-pytest--node-id-class-at-point ()
+(defun python-pytest--node-id-class-at-point-treesit ()
   "Return the node id of the class at point.
 
 + If the class is not inside another class, its node id is the name

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -1,7 +1,7 @@
 ;;; python-pytest.el --- helpers to run pytest -*- lexical-binding: t; -*-
 
 ;; Author: wouter bolsterlee <wouter@bolsterl.ee>
-;; Version: 3.3.0
+;; Version: 3.5.0
 ;; Package-Requires: ((emacs "24.4") (dash "2.18.0") (transient "0.3.7") (s "1.12.0"))
 ;; Keywords: pytest, test, python, languages, processes, tools
 ;; URL: https://github.com/wbolster/emacs-python-pytest

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -178,7 +178,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
     ("F" "file (this)" python-pytest-file)]
    [("m" "files" python-pytest-files)
     ("M" "directories" python-pytest-directories)]
-   [("d" "def/class (dwim)" python-pytest-function-dwim)
+   [("d" "def at point (dwim)" python-pytest-run-def-at-point-dwim)
     ("D" "def at point" python-pytest-run-def-at-point)
     ("c" "class at point" python-pytest-run-class-at-point)]])
 
@@ -297,11 +297,16 @@ With a prefix argument, allow editing."
    :edit current-prefix-arg))
 
 ;;;###autoload
-(defun python-pytest-function-dwim (file func args)
-  "Run pytest on FILE with FUNC (or class).
+(defun python-pytest-run-def-at-point-dwim (file func args)
+  "Run pytest on FILE using FUNC at point as the node-id.
 
-When run interactively, this tries to work sensibly using
-the current file and function around point.
+If `python-pytest--test-file-p' returns t for FILE (i.e. the file
+is a test file), then this function results in the same behavior
+as calling `python-pytest-run-def-at-point'. If
+`python-pytest--test-file-p' returns nil for FILE (i.e. the
+current file is not a test file), then this function will try to
+find related test files and test defs (i.e. sensible match) for
+the current file and the def at point.
 
 Additional ARGS are passed along to pytest.
 With a prefix argument, allow editing."

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -178,7 +178,7 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
     ("F" "file (this)" python-pytest-file)]
    [("m" "files" python-pytest-files)
     ("M" "directories" python-pytest-directories)]
-   [("d" "def at point (dwim)" python-pytest-run-def-at-point-dwim)
+   [("d" "def at point (dwim)" python-pytest-run-def-or-class-at-point-dwim)
     ("D" "def at point" python-pytest-run-def-at-point-treesit)
     ("c" "class at point" python-pytest-run-class-at-point-treesit)]])
 
@@ -279,7 +279,7 @@ With a prefix argument, allow editing."
    :edit current-prefix-arg))
 
 ;;;###autoload
-(defun python-pytest-function (file func args)
+(defun python-pytest-run-def-or-class-at-point (file func args)
   "Run pytest on FILE with FUNC (or class).
 
 Additional ARGS are passed along to pytest.
@@ -296,7 +296,7 @@ With a prefix argument, allow editing."
    :edit current-prefix-arg))
 
 ;;;###autoload
-(defun python-pytest-run-def-at-point-dwim (file func args)
+(defun python-pytest-run-def-or-class-at-point-dwim (file func args)
   "Run pytest on FILE using FUNC at point as the node-id.
 
 If `python-pytest--test-file-p' returns t for FILE (i.e. the file

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -127,6 +127,16 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
            (set-default symbol value)
            value))))
 
+(defcustom python-pytest-use-treesit nil
+  "Whether to use treesit for getting the node ids of things at point.
+
+Users that are running a version of Emacs that supports treesit
+and have the Python language grammar for treesit should set this
+variable to t. Users that are running a version of Emacs that
+don't support treesit should set this variable to nil."
+  :group 'python-pytest
+  :type 'boolean)
+
 (defvar python-pytest--history nil
   "History for pytest invocations.")
 
@@ -178,9 +188,10 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
     ("F" "file (this)" python-pytest-file)]
    [("m" "files" python-pytest-files)
     ("M" "directories" python-pytest-directories)]
-   [("d" "def at point (dwim)" python-pytest-run-def-or-class-at-point-dwim)
-    ("D" "def at point" python-pytest-run-def-at-point-treesit)
-    ("c" "class at point" python-pytest-run-class-at-point-treesit)]])
+   [("d" "def at point (dwim)" python-pytest-run-def-or-class-at-point-dwim :if-not python-pytest-use-treesit-p)
+    ("D" "def at point" python-pytest-run-def-or-class-at-point :if-not python-pytest-use-treesit-p)
+    ("d" "def at point" python-pytest-run-def-at-point-treesit :if python-pytest-use-treesit-p)
+    ("c" "class at point" python-pytest-run-class-at-point-treesit :if python-pytest-use-treesit-p)]])
 
 (define-obsolete-function-alias 'python-pytest-popup 'python-pytest-dispatch "2.0.0")
 
@@ -460,6 +471,17 @@ TestClassParent::TestClassChild::test_my_function."
       (run-hooks 'python-pytest-started-hook)
       (setq process (get-buffer-process buffer))
       (set-process-sentinel process #'python-pytest--process-sentinel))))
+
+(defun python-pytest-use-treesit-p ()
+  "Return t if python-pytest-use-treesit is t. Otherwise, return nil.
+
+This function is passed to the parameter :if in
+`python-pytest-dispatch'.
+
+Although this function might look useless, the main reason why it
+was defined was that the parameter that is provided to the
+transient keyword :if must be a function."
+  python-pytest-use-treesit)
 
 (defun python-pytest--shell-quote (s)
   "Quote S for use in a shell command. Like `shell-quote-argument', but prettier."

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -600,7 +600,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
 
 ;; python helpers
 
-(defun python-pytest--point-is-inside-def ()
+(defun python-pytest--point-is-inside-def-treesit ()
   (unless (treesit-language-available-p 'python)
     (error "This function requires tree-sitter support for python, but it is not available."))
   (catch 'return
@@ -609,7 +609,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
         (when (equal (treesit-node-type current-node) "function_definition")
           (throw 'return t))))))
 
-(defun python-pytest--point-is-inside-class ()
+(defun python-pytest--point-is-inside-class-treesit ()
   (unless (treesit-language-available-p 'python)
     (error "This function requires tree-sitter support for python, but it is not available."))
   (catch 'return
@@ -628,7 +628,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
 + If the test function is defined inside a class that is defined
   inside another class, its node id would look like:
   TestGroupParent::TestGroupChild::test_my_function."
-  (unless (python-pytest--point-is-inside-def)
+  (unless (python-pytest--point-is-inside-def-treesit)
     (error "The point is not inside a def."))
   (let ((function
          ;; Move up to the outermost function
@@ -691,7 +691,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
   class which is contained would be: TestGroupParent::TestGroupChild,
   while the node id of the class which contains the other class would
   be TestGroupParent."
-  (unless (python-pytest--point-is-inside-class)
+  (unless (python-pytest--point-is-inside-class-treesit)
     (error "The point is not inside a class."))
   (let ((class
          ;; Move up to the outermost function

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -284,6 +284,7 @@ With a prefix argument, allow editing."
 
 Additional ARGS are passed along to pytest.
 With a prefix argument, allow editing."
+  (declare (obsolete 'python-pytest-run-def-at-point "python-pytest 3.5.0"))
   (interactive
    (list
     (buffer-file-name)

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -189,10 +189,10 @@ don't support treesit should set this variable to nil."
     ("F" "file (this)" python-pytest-file)]
    [("m" "files" python-pytest-files)
     ("M" "directories" python-pytest-directories)]
-   [("d" "def at point (dwim)" python-pytest-run-def-or-class-at-point-dwim :if-not python-pytest-use-treesit-p)
-    ("D" "def at point" python-pytest-run-def-or-class-at-point :if-not python-pytest-use-treesit-p)
-    ("d" "def at point" python-pytest-run-def-at-point-treesit :if python-pytest-use-treesit-p)
-    ("c" "class at point" python-pytest-run-class-at-point-treesit :if python-pytest-use-treesit-p)]])
+   [("d" "def at point (dwim)" python-pytest-run-def-or-class-at-point-dwim :if-not python-pytest--use-treesit-p)
+    ("D" "def at point" python-pytest-run-def-or-class-at-point :if-not python-pytest--use-treesit-p)
+    ("d" "def at point" python-pytest-run-def-at-point-treesit :if python-pytest--use-treesit-p)
+    ("c" "class at point" python-pytest-run-class-at-point-treesit :if python-pytest--use-treesit-p)]])
 
 (define-obsolete-function-alias 'python-pytest-popup 'python-pytest-dispatch "2.0.0")
 
@@ -473,7 +473,7 @@ TestClassParent::TestClassChild::test_my_function."
       (setq process (get-buffer-process buffer))
       (set-process-sentinel process #'python-pytest--process-sentinel))))
 
-(defun python-pytest-use-treesit-p ()
+(defun python-pytest--use-treesit-p ()
   "Return t if python-pytest-use-treesit is t. Otherwise, return nil.
 
 This function is passed to the parameter :if in

--- a/python-pytest.el
+++ b/python-pytest.el
@@ -287,7 +287,7 @@ With a prefix argument, allow editing."
   (interactive
    (list
     (buffer-file-name)
-    (python-pytest--current-defun)
+    (python-pytest--node-id-def-or-class-at-point)
     (transient-args 'python-pytest-dispatch)))
   (python-pytest--run
    :args args
@@ -312,7 +312,7 @@ With a prefix argument, allow editing."
   (interactive
    (list
     (buffer-file-name)
-    (python-pytest--current-defun)
+    (python-pytest--node-id-def-or-class-at-point)
     (transient-args 'python-pytest-dispatch)))
   (unless (python-pytest--test-file-p file)
     (setq
@@ -703,7 +703,7 @@ When present ON-REPLACEMENT is substituted, else OFF-REPLACEMENT is appended."
                     parents))))))
     (string-join `(,@parents ,(cdr class)) "::")))
 
-(defun python-pytest--current-defun ()
+(defun python-pytest--node-id-def-or-class-at-point ()
   "Detect the current function/class (if any)."
   (let* ((name
           (or (python-info-current-defun)

--- a/tests/README.org
+++ b/tests/README.org
@@ -1,0 +1,9 @@
+The following command can be used to run all tests in the directory =tests=. The command should be run in the root directory of the project. The command explicitly loads the file =python-pytest.el= in this repository, this is done to make sure that Emacs uses the symbol definitions from that file instead of other locations that might have the same package (e.g. installed through MELPA.)
+
+#+BEGIN_SRC sh
+emacs \
+  --batch \
+  --eval '(load-file "./python-pytest.el")' \
+  --eval '(dolist (file (directory-files-recursively "tests" "\\`[^.].*\\.el\\'\''")) (load-file file))' \
+  --eval '(ert-run-tests-batch-and-exit)'
+#+END_SRC

--- a/tests/test-python-helpers.el
+++ b/tests/test-python-helpers.el
@@ -27,7 +27,25 @@
     (forward-line 1)
     (should (equal (python-pytest--node-id-def-at-point-treesit) "bar"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point-treesit) "bar"))))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "bar"))
+    ;; when the buffer is narrowed, we should get the same result.
+    (goto-char (point-min))
+    (search-forward "foo")
+    (save-restriction
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "foo")))
+    (forward-line 1)
+    (save-restriction
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "foo")))
+    (forward-line 1)
+    (save-restriction
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "bar")))
+    (forward-line 1)
+    (save-restriction
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "bar")))))
 
 (ert-deftest get-current-def-inside-class ()
   (pytest-test-with-temp-text (concat
@@ -42,7 +60,25 @@
     (forward-line 1)
     (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::bar"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::bar"))))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::bar"))
+    ;; when the buffer is narrowed, we should get the same result
+    (goto-char (point-min))
+    (search-forward "foo")
+    (save-restriction
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::foo")))
+    (forward-line 1)
+    (save-restriction
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::foo")))
+    (forward-line 1)
+    (save-restriction
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::bar")))
+    (forward-line 1)
+    (save-restriction
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::bar")))))
 
 (ert-deftest get-current-def-inside-multiple-classes ()
   (pytest-test-with-temp-text (string-join
@@ -61,7 +97,25 @@
     (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
     (forward-line 1)
     (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
-    (forward-line 1))
+    (forward-line 1)
+    ;; when the buffer is narrowed, we should get the same result.
+    (goto-char (point-min))
+    (save-restriction
+      (search-forward "foo")
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::foo")))
+    (save-restriction
+      (forward-line 1)
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::foo")))
+    (save-restriction
+      (forward-line 1)
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::bar")))
+    (save-restriction
+      (forward-line 1)
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))))
   (pytest-test-with-temp-text (string-join
                                '("class TestDepthOne:"
                                  "  def test_depth_one():<point>"
@@ -77,7 +131,21 @@
     (search-forward "test_depth_two")
     (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::test_depth_two"))
     (search-forward "test_depth_three")
-    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::test_depth_three"))))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::test_depth_three"))
+    ;; when the buffer is narrowed, we should get the same result.
+    (goto-char (point-min))
+    (save-restriction
+      (search-forward "test_depth_one")
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::test_depth_one")))
+    (save-restriction
+      (search-forward "test_depth_two")
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::test_depth_two")))
+    (save-restriction
+      (search-forward "test_depth_three")
+      (narrow-to-defun)
+      (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::test_depth_three")))))
 
 (ert-deftest get-current-def-inside-def ()
   (pytest-test-with-temp-text (string-join
@@ -85,6 +153,8 @@
                                  "  def bar():"
                                  "    pass<point>")
                                "\n")
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "foo"))
+    (narrow-to-defun)
     (should (equal (python-pytest--node-id-def-at-point-treesit) "foo")))
   (pytest-test-with-temp-text (string-join
                                '("class TestDepthOne:"
@@ -98,6 +168,9 @@
     ;; identify defs inside defs. In other words, pytest can
     ;; only identify those defs that are not contained within
     ;; other defs.
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))
+    ;; when the buffer is narrowed, we should get the same result.
+    (narrow-to-defun)
     (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))))
 
 (ert-deftest get-current-class-outside-class ()
@@ -106,15 +179,24 @@
                                  "  def foo():"
                                  "    pass<point>")
                                "\n")
+    (should (equal (python-pytest--node-id-class-at-point-treesit) "Test"))
+    ;; when the buffer is narrowed, we should get the same result.
+    (narrow-to-defun)
     (should (equal (python-pytest--node-id-class-at-point-treesit) "Test"))))
 
 (ert-deftest get-current-class-inside-class ()
+  ;; when the buffer is not narrowed
   (pytest-test-with-temp-text (string-join
                                '("class TestDepthOne:"
                                  "  class TestDepthTwo:"
                                  "    def foo():"
                                  "      pass<point>")
                                "\n")
+    (should (equal
+             (python-pytest--node-id-class-at-point-treesit)
+             "TestDepthOne::TestDepthTwo"))
+    ;; when the buffer is narrowed, we should get the same result.
+    (narrow-to-defun)
     (should (equal
              (python-pytest--node-id-class-at-point-treesit)
              "TestDepthOne::TestDepthTwo"))))
@@ -129,6 +211,11 @@
                                  "          def foo():"
                                  "            pass<point>")
                                "\n")
+    (should (equal
+             (python-pytest--node-id-class-at-point-treesit)
+             "TestDepthOne::TestDepthTwo::TestDepthThree::TestDepthFour::TestDepthFive"))
+    ;; when the buffer is narrowed, we should get the same result.
+    (narrow-to-defun)
     (should (equal
              (python-pytest--node-id-class-at-point-treesit)
              "TestDepthOne::TestDepthTwo::TestDepthThree::TestDepthFour::TestDepthFive"))))

--- a/tests/test-python-helpers.el
+++ b/tests/test-python-helpers.el
@@ -21,13 +21,13 @@
                                "  pass\n"
                                "def bar():\n"
                                "  pass\n")
-    (should (equal (python-pytest--path-def-at-point) "foo"))
+    (should (equal (python-pytest--node-id-def-at-point) "foo"))
     (forward-line 1)
-    (should (equal (python-pytest--path-def-at-point) "foo"))
+    (should (equal (python-pytest--node-id-def-at-point) "foo"))
     (forward-line 1)
-    (should (equal (python-pytest--path-def-at-point) "bar"))
+    (should (equal (python-pytest--node-id-def-at-point) "bar"))
     (forward-line 1)
-    (should (equal (python-pytest--path-def-at-point) "bar"))))
+    (should (equal (python-pytest--node-id-def-at-point) "bar"))))
 
 (ert-deftest get-current-def-inside-class ()
   (pytest-test-with-temp-text (concat
@@ -36,13 +36,13 @@
                                "    pass\n"
                                "  def bar():\n"
                                "    pass\n")
-    (should (equal (python-pytest--path-def-at-point) "TestGroup::foo"))
+    (should (equal (python-pytest--node-id-def-at-point) "TestGroup::foo"))
     (forward-line 1)
-    (should (equal (python-pytest--path-def-at-point) "TestGroup::foo"))
+    (should (equal (python-pytest--node-id-def-at-point) "TestGroup::foo"))
     (forward-line 1)
-    (should (equal (python-pytest--path-def-at-point) "TestGroup::bar"))
+    (should (equal (python-pytest--node-id-def-at-point) "TestGroup::bar"))
     (forward-line 1)
-    (should (equal (python-pytest--path-def-at-point) "TestGroup::bar"))))
+    (should (equal (python-pytest--node-id-def-at-point) "TestGroup::bar"))))
 
 (ert-deftest get-current-def-inside-multiple-classes ()
   (pytest-test-with-temp-text (string-join
@@ -54,13 +54,13 @@
                                  "      def bar():"
                                  "        pass")
                                "\n")
-    (should (equal (python-pytest--path-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))
+    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))
     (forward-line 1)
-    (should (equal (python-pytest--path-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))
+    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))
     (forward-line 1)
-    (should (equal (python-pytest--path-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
+    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
     (forward-line 1)
-    (should (equal (python-pytest--path-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
+    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
     (forward-line 1))
   (pytest-test-with-temp-text (string-join
                                '("class TestDepthOne:"
@@ -73,11 +73,11 @@
                                  "      def test_depth_three():"
                                  "        pass")
                                "\n")
-    (should (equal (python-pytest--path-def-at-point) "TestDepthOne::test_depth_one"))
+    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::test_depth_one"))
     (search-forward "test_depth_two")
-    (should (equal (python-pytest--path-def-at-point) "TestDepthOne::TestDepthTwo::test_depth_two"))
+    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::test_depth_two"))
     (search-forward "test_depth_three")
-    (should (equal (python-pytest--path-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::test_depth_three"))))
+    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::test_depth_three"))))
 
 (ert-deftest get-current-def-inside-def ()
   (pytest-test-with-temp-text (string-join
@@ -85,7 +85,7 @@
                                  "  def bar():"
                                  "    pass<point>")
                                "\n")
-    (should (equal (python-pytest--path-def-at-point) "foo")))
+    (should (equal (python-pytest--node-id-def-at-point) "foo")))
   (pytest-test-with-temp-text (string-join
                                '("class TestDepthOne:"
                                  "  class TestDepthTwo:"
@@ -98,7 +98,7 @@
     ;; identify defs inside defs. In other words, pytest can
     ;; only identify those defs that are not contained within
     ;; other defs.
-    (should (equal (python-pytest--path-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))))
+    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))))
 
 (ert-deftest get-current-class-outside-class ()
   (pytest-test-with-temp-text (string-join
@@ -106,7 +106,7 @@
                                  "  def foo():"
                                  "    pass<point>")
                                "\n")
-    (should (equal (python-pytest--path-class-at-point) "Test"))))
+    (should (equal (python-pytest--node-id-class-at-point) "Test"))))
 
 (ert-deftest get-current-class-inside-class ()
   (pytest-test-with-temp-text (string-join
@@ -116,7 +116,7 @@
                                  "      pass<point>")
                                "\n")
     (should (equal
-             (python-pytest--path-class-at-point)
+             (python-pytest--node-id-class-at-point)
              "TestDepthOne::TestDepthTwo"))))
 
 (ert-deftest get-current-class-inside-multiple-classes ()
@@ -130,5 +130,5 @@
                                  "            pass<point>")
                                "\n")
     (should (equal
-             (python-pytest--path-class-at-point)
+             (python-pytest--node-id-class-at-point)
              "TestDepthOne::TestDepthTwo::TestDepthThree::TestDepthFour::TestDepthFive"))))

--- a/tests/test-python-helpers.el
+++ b/tests/test-python-helpers.el
@@ -21,13 +21,13 @@
                                "  pass\n"
                                "def bar():\n"
                                "  pass\n")
-    (should (equal (python-pytest--node-id-def-at-point) "foo"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "foo"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point) "foo"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "foo"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point) "bar"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "bar"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point) "bar"))))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "bar"))))
 
 (ert-deftest get-current-def-inside-class ()
   (pytest-test-with-temp-text (concat
@@ -36,13 +36,13 @@
                                "    pass\n"
                                "  def bar():\n"
                                "    pass\n")
-    (should (equal (python-pytest--node-id-def-at-point) "TestGroup::foo"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::foo"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point) "TestGroup::foo"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::foo"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point) "TestGroup::bar"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::bar"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point) "TestGroup::bar"))))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestGroup::bar"))))
 
 (ert-deftest get-current-def-inside-multiple-classes ()
   (pytest-test-with-temp-text (string-join
@@ -54,13 +54,13 @@
                                  "      def bar():"
                                  "        pass")
                                "\n")
-    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
     (forward-line 1)
-    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::bar"))
     (forward-line 1))
   (pytest-test-with-temp-text (string-join
                                '("class TestDepthOne:"
@@ -73,11 +73,11 @@
                                  "      def test_depth_three():"
                                  "        pass")
                                "\n")
-    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::test_depth_one"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::test_depth_one"))
     (search-forward "test_depth_two")
-    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::test_depth_two"))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::test_depth_two"))
     (search-forward "test_depth_three")
-    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::test_depth_three"))))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::test_depth_three"))))
 
 (ert-deftest get-current-def-inside-def ()
   (pytest-test-with-temp-text (string-join
@@ -85,7 +85,7 @@
                                  "  def bar():"
                                  "    pass<point>")
                                "\n")
-    (should (equal (python-pytest--node-id-def-at-point) "foo")))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "foo")))
   (pytest-test-with-temp-text (string-join
                                '("class TestDepthOne:"
                                  "  class TestDepthTwo:"
@@ -98,7 +98,7 @@
     ;; identify defs inside defs. In other words, pytest can
     ;; only identify those defs that are not contained within
     ;; other defs.
-    (should (equal (python-pytest--node-id-def-at-point) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))))
+    (should (equal (python-pytest--node-id-def-at-point-treesit) "TestDepthOne::TestDepthTwo::TestDepthThree::foo"))))
 
 (ert-deftest get-current-class-outside-class ()
   (pytest-test-with-temp-text (string-join
@@ -106,7 +106,7 @@
                                  "  def foo():"
                                  "    pass<point>")
                                "\n")
-    (should (equal (python-pytest--node-id-class-at-point) "Test"))))
+    (should (equal (python-pytest--node-id-class-at-point-treesit) "Test"))))
 
 (ert-deftest get-current-class-inside-class ()
   (pytest-test-with-temp-text (string-join
@@ -116,7 +116,7 @@
                                  "      pass<point>")
                                "\n")
     (should (equal
-             (python-pytest--node-id-class-at-point)
+             (python-pytest--node-id-class-at-point-treesit)
              "TestDepthOne::TestDepthTwo"))))
 
 (ert-deftest get-current-class-inside-multiple-classes ()
@@ -130,5 +130,5 @@
                                  "            pass<point>")
                                "\n")
     (should (equal
-             (python-pytest--node-id-class-at-point)
+             (python-pytest--node-id-class-at-point-treesit)
              "TestDepthOne::TestDepthTwo::TestDepthThree::TestDepthFour::TestDepthFive"))))


### PR DESCRIPTION
The `master` branch uses the function `python-pytest--current-defun` for getting the test id of the function at point or class at point and it supports at most 2 parts. The changes in this pull request adds two functions: `python-pytest--node-id-def-at-point` [(link)](https://github.com/wbolster/emacs-python-pytest/pull/75/files#diff-ec3a68c754a7f498ad96a584a259278a8827ede06e61b45dc43176e1f2dd92f5R599) and `python-pytest--node-id-class-at-point` [(link)](https://github.com/wbolster/emacs-python-pytest/pull/75/files#diff-ec3a68c754a7f498ad96a584a259278a8827ede06e61b45dc43176e1f2dd92f5R663) which get the path for the `def` or `class` at point for an arbitrary number of nested classes, these two functions use tree-sitter. See the file `tests/test-python-helpers.el` [(link to file)](https://github.com/wbolster/emacs-python-pytest/pull/75/files#diff-81f0e7d900796fab670b25e21714624fa1496e4f31987f18d89074d7404f9654) for examples on how these functions behave. By having two functions for different purposes, the user has more control over what to execute (e.g. (s)he could execute a Test class when the point is on a function).

Please let me know what you think of these changes, so that I can improve this pull request to suit more use cases.