### PR TITLE
#76: add instructions for python language grammar.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,11 @@ if a project has a conventional layout.
 
 __ https://github.com/bbatsov/projectile
 
+You will need also `tree-sitter` for function/class tests run. You can
+install python language grammar using::
+
+  M-x treesit-install-language-grammar
+
 
 usage
 =====

--- a/README.rst
+++ b/README.rst
@@ -122,8 +122,7 @@ if a project has a conventional layout.
 
 __ https://github.com/bbatsov/projectile
 
-You will need also `tree-sitter` for function/class tests run. You can
-install python language grammar using::
+to run function/class tests, ``tree-sitter`` is needed, including the python language grammar::
 
   M-x treesit-install-language-grammar
 


### PR DESCRIPTION
Closes #76 

Clarify documentation for tree-sitter.